### PR TITLE
Fix system icon loading

### DIFF
--- a/font-scaler@patrick.gaubatz.at/extension.js
+++ b/font-scaler@patrick.gaubatz.at/extension.js
@@ -25,6 +25,8 @@ const Gtk = imports.gi.Gtk
 const Main = imports.ui.main
 const PanelMenu = imports.ui.panelMenu
 
+const Me = imports.misc.extensionUtils.getCurrentExtension();
+
 const KEY = 'text-scaling-factor'
 const NAME = 'Font Scaler'
 const ICON = 'icon'
@@ -39,9 +41,9 @@ const FontScaler = new Lang.Class({
     this.parent(null, NAME)
     this.settings = new Gio.Settings({ schema_id: 'org.gnome.desktop.interface' })
     this._icon = new St.Icon({
-      icon_name: ICON,
       style_class: 'system-status-icon'
     })
+    this._icon.gicon = Gio.icon_new_for_string(`${Me.path}/${ICON}.svg`);
     this.actor.add_actor(this._icon)
     this.actor.add_style_class_name('panel-status-button')
     this.actor.connect('button-press-event', Lang.bind(this, this.toggle))


### PR DESCRIPTION
With Gnome 3.36 the icon is not loaded properly in the
system tray

The fix consists in loading the custom extension icon giving the proper
path.