### PR TITLE
Removed deprecated usage of object.actor and support 3.36

### DIFF
--- a/font-scaler@patrick.gaubatz.at/extension.js
+++ b/font-scaler@patrick.gaubatz.at/extension.js
@@ -42,9 +42,9 @@ const FontScaler = new Lang.Class({
       icon_name: ICON,
       style_class: 'system-status-icon'
     })
-    this.actor.add_actor(this._icon)
-    this.actor.add_style_class_name('panel-status-button')
-    this.actor.connect('button-press-event', Lang.bind(this, this.toggle))
+    this.add_actor(this._icon)
+    this.add_style_class_name('panel-status-button')
+    this.connect('button-press-event', Lang.bind(this, this.toggle))
   },
   toggle: function () {
     const value = this.settings.get_double(KEY) === 1 ? 1.3 : 1

--- a/font-scaler@patrick.gaubatz.at/metadata.json
+++ b/font-scaler@patrick.gaubatz.at/metadata.json
@@ -3,7 +3,7 @@
   "uuid": "font-scaler@patrick.gaubatz.at",
   "name": "Font Scaler",
   "description": "Font Scaler",
-  "shell-version": [ "3.12", "3.14", "3.16" ],
+  "shell-version": [ "3.12", "3.14", "3.16", "3.36" ],
   "original-authors": [ "patrick@gaubatz.at" ],
   "url": "https://github.com/pgaubatz/gnome-shell-extension-font-scaler"
 }


### PR DESCRIPTION
Testing on Gnome shell 3.36, it seems that the only fix needed to make
it work on 3.36 is the deprecated usage of object.actor